### PR TITLE
GH-52: feat: Smart error handling in s3_utils.retry_decorator() and profile support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 default_stages: [pre-commit]
+default_language_version:
+  python: python3.12
 repos:
   - repo: meta
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "ExifRead==3.5.1",
     "PyYAML==6.0.3",
     "boto3>=1.42.66",
+    "botocore>=1.42.66",
 ]
 
 [project.scripts]

--- a/src/file_manager/file_manager.py
+++ b/src/file_manager/file_manager.py
@@ -199,6 +199,9 @@ def parse_arguments() -> argparse.Namespace:
         "-e", "--etag", type=str, default="", help="ETag to compare with, if not specified will be calculated from file content")
 
     args = arg_parser.parse_args()
+    if not hasattr(args, "cmd_name"):
+        arg_parser.error(f"You have to specify command to run, available commands are: {', '.join(subparsers.choices.keys())}")
+
     if args.cmd_name in disk_required and not args.disk:
         arg_parser.error(f"-d DISK argument is required for {args.cmd_name}")
 

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -23,9 +23,9 @@ def retry_decorator(func: Callable) -> Callable:
         while True:
             try:
                 return func(*args, **kwargs)
-            except ClientError:
+            except ClientError as e:
                 _retry_count += 1
-                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} retry {_retry_count} with new client...")
+                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} dur to:\n{e}\nRetry {_retry_count} with new client...")
                 kwargs["client"].set_client()
                 if _retry_count > 1:
                     sleep(_CLIENT_RETRY_TIMEOUT)

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -135,7 +135,7 @@ class S3Client(StorageClient):
             except PermissionError as error:
                 duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
                 logging.error(f"Permission error while reading file attributes for s3://{self._bucket}/{self._prefix}: {error}")
-                return file_name, file_type, 0, 0.0, "unknown-no-access", duration
+                return file_name, file_type, 1, 0.0, "unknown-no-access", duration
 
         duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
         logging.debug(f"read_file_info for s3://{self._bucket}/{self._prefix}/{file_path} in {duration / 1E9:.2f} sec. got {response}")

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -25,7 +25,7 @@ def retry_decorator(func: Callable) -> Callable:
                 return func(*args, **kwargs)
             except ClientError as e:
                 _retry_count += 1
-                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} dur to:\n{e}\nRetry {_retry_count} with new client...")
+                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} due to:\n{e}\nRetry {_retry_count} with new client...")
                 kwargs["client"].set_client()
                 if _retry_count > 1:
                     sleep(_CLIENT_RETRY_TIMEOUT)

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -61,11 +61,6 @@ def read_file_info(client: S3Client, key: str) -> Any:
     return client.session_client.head_object(Bucket=client._bucket, Key=key)
 
 
-@retry_decorator
-def read_file_attributes(client: S3Client, key: str) -> Any:
-    return client.session_client.get_object_attributes(Bucket=client._bucket, Key=key, ObjectAttributes=["ETag", "ObjectSize", "StorageClass"])
-
-
 class S3Client(StorageClient):
     def __init__(self, media: str) -> None:
         self.set_media(media)
@@ -125,17 +120,8 @@ class S3Client(StorageClient):
             response = read_file_info(client=self, key=f"{self._prefix}/{file_path}" if self._prefix else file_path)
         except PermissionError as error:
             logging.error(f"Permission error while reading file info for s3://{self._bucket}/{self._prefix}: {error}")
-            try:
-                response = read_file_attributes(client=self, key=f"{self._prefix}/{file_path}" if self._prefix else file_path)
-                duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
-                return (
-                    file_name, file_type, response["ObjectSize"], response["LastModified"].timestamp(),
-                    response["ETag"].strip('"'), duration
-                )
-            except PermissionError as error:
-                duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
-                logging.error(f"Permission error while reading file attributes for s3://{self._bucket}/{self._prefix}: {error}")
-                return file_name, file_type, 1, 0.0, "unknown-no-access", duration
+            duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
+            return file_name, file_type, 1, 0.0, "", duration
 
         duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
         logging.debug(f"read_file_info for s3://{self._bucket}/{self._prefix}/{file_path} in {duration / 1E9:.2f} sec. got {response}")

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -13,6 +13,10 @@ from file_manager.storage_client import StorageClient
 _CLIENT_RETRY_TIMEOUT = 30  # seconds
 
 
+class PermissionError(ClientError):
+    pass
+
+
 def retry_decorator(func: Callable) -> Callable:
     """Decorator to retry a function on ClientError, with a new client instance.
     The function must have a 'client' keyword argument which is an instance of S3Client.
@@ -23,9 +27,11 @@ def retry_decorator(func: Callable) -> Callable:
         while True:
             try:
                 return func(*args, **kwargs)
-            except ClientError as e:
+            except ClientError as error:
+                if error.response['ResponseMetadata']['HTTPStatusCode'] == 403:
+                    raise PermissionError(error.response, error.operation_name) from error
                 _retry_count += 1
-                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} due to:\n{e}\nRetry {_retry_count} with new client...")
+                logging.warning(f"{func.__name__} failed for with args {args}, {kwargs} due to:\n{error}\nRetry {_retry_count} with new client...")
                 kwargs["client"].set_client()
                 if _retry_count > 1:
                     sleep(_CLIENT_RETRY_TIMEOUT)
@@ -53,6 +59,11 @@ def read_dir(client: S3Client) -> tuple[list[str], list[str]]:
 @retry_decorator
 def read_file_info(client: S3Client, key: str) -> Any:
     return client.session_client.head_object(Bucket=client._bucket, Key=key)
+
+
+@retry_decorator
+def read_file_attributes(client: S3Client, key: str) -> Any:
+    return client.session_client.get_object_attributes(Bucket=client._bucket, Key=key, ObjectAttributes=["ETag", "ObjectSize", "StorageClass"])
 
 
 class S3Client(StorageClient):
@@ -95,11 +106,14 @@ class S3Client(StorageClient):
         return self._prefix.split("/") if self._prefix else [""]
 
     def read_dir(self) -> tuple[list[str], list[str]]:
-        return read_dir(client=self)
+        try:
+            return read_dir(client=self)
+        except PermissionError as error:
+            logging.error(f"Permission error while reading directory for s3://{self._bucket}/{self._prefix}: {error}")
+            return [], []
 
     def read_file_info(self, file_path: str, get_hash: bool = False) -> tuple[str, str, int, float, str, int]:
         start_time = clock_gettime_ns(CLOCK_MONOTONIC)
-        response = read_file_info(client=self, key=f"{self._prefix}/{file_path}" if self._prefix else file_path)
         file_name_parts = file_path.split(".")
         if len(file_name_parts) > 1 and file_name_parts[0]:
             file_type = file_name_parts[-1]
@@ -107,6 +121,22 @@ class S3Client(StorageClient):
         else:
             file_name = file_path
             file_type = ""
+        try:
+            response = read_file_info(client=self, key=f"{self._prefix}/{file_path}" if self._prefix else file_path)
+        except PermissionError as error:
+            logging.error(f"Permission error while reading file info for s3://{self._bucket}/{self._prefix}: {error}")
+            try:
+                response = read_file_attributes(client=self, key=f"{self._prefix}/{file_path}" if self._prefix else file_path)
+                duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
+                return (
+                    file_name, file_type, response["ObjectSize"], response["LastModified"].timestamp(),
+                    response["ETag"].strip('"'), duration
+                )
+            except PermissionError as error:
+                duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
+                logging.error(f"Permission error while reading file attributes for s3://{self._bucket}/{self._prefix}: {error}")
+                return file_name, file_type, 0, 0.0, "unknown-no-access", duration
+
         duration = clock_gettime_ns(CLOCK_MONOTONIC) - start_time
         logging.debug(f"read_file_info for s3://{self._bucket}/{self._prefix}/{file_path} in {duration / 1E9:.2f} sec. got {response}")
         return (

--- a/src/file_manager/s3_utils.py
+++ b/src/file_manager/s3_utils.py
@@ -62,12 +62,13 @@ def read_file_info(client: S3Client, key: str) -> Any:
 
 
 class S3Client(StorageClient):
-    def __init__(self, media: str) -> None:
+    def __init__(self, media: str, profile: str) -> None:
+        self.profile = profile
         self.set_media(media)
         self.set_client()
 
     def set_client(self):
-        new_session = boto3.Session()
+        new_session = boto3.Session(profile_name=self.profile)
         credentials = new_session.get_credentials()
         self.session_client = new_session.client("s3")
         logging.info(f"Created new S3 client for bucket {self._bucket} with access key {credentials.access_key}")

--- a/src/file_manager/storage_interface.py
+++ b/src/file_manager/storage_interface.py
@@ -5,7 +5,7 @@ from file_manager.s3_utils import S3Client
 from file_manager.storage_client import StorageClient
 
 
-def get_storage_client(media: str) -> StorageClient:
+def get_storage_client(media: str, profile: str) -> StorageClient:
     if media.startswith("s3://"):
-        return S3Client(media)
+        return S3Client(media, profile)
     return FsClient(media)

--- a/src/file_manager/update_database.py
+++ b/src/file_manager/update_database.py
@@ -43,6 +43,12 @@ def main(argv: Any=[]) -> None:
         help="Database file",
         required=False,
         default=DEFAULT_DATABASE)
+    arg_parser.add_argument(
+        "--aws-profile",
+        type=str,
+        help="AWS profile to use for S3 access, if not specified will use default profile",
+        required=False,
+        default='default')
     os_cpu_count = os.cpu_count()
     default_threads = os_cpu_count // 4 if os_cpu_count else DEFAULT_MAX_FILE_UPDATE_THREADS
     arg_parser.add_argument("-t", "--threads",
@@ -61,7 +67,7 @@ def main(argv: Any=[]) -> None:
 
     rehash_time = time.time() - args.rehash_interval * 24 * 3600
     with FileDatabaseUpdater(
-          args.database, rehash_time, args.threads, get_storage_client(args.media)) as file_db:
+          args.database, rehash_time, args.threads, get_storage_client(args.media, args.aws_profile)) as file_db:
         file_db.update_dir(max_depth=args.max_depth)
         file_db.handle_orfans(clear_orfan_files=args.clear_orfan_files)
 

--- a/src/file_manager/update_database.py
+++ b/src/file_manager/update_database.py
@@ -25,6 +25,7 @@ def main(argv: Any=[]) -> None:
         description="Load files to database")
     arg_parser.add_argument("--media", type=str,
                             help="Media to import files from",
+                            required=True,
                             default=None)
     arg_parser.add_argument(
         "--max_depth",


### PR DESCRIPTION
1. Keep running on PermissionError during scan
2. Support non-default AWS profile
3. Correctly handle no arguments for update_database and file_manager